### PR TITLE
Drop gettext requirement to 0.18.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -145,7 +145,7 @@ AS_IF([$TEST "x$ITSTOOL" = xitstool-notfound -a -d .git],
 
 ### INTERNATIONALIZATION #######################################################
 
-AM_GNU_GETTEXT_VERSION([0.19.2])
+AM_GNU_GETTEXT_VERSION([0.18.3])
 # 0.18.3 required for Glade files; but use last point release from supported
 # distros (currently openSUSE 13.2 has this version, Debian stable has .3)
 GETTEXT_PACKAGE=gnome-inform7


### PR DESCRIPTION
Actually openSUSE 13.2 provides 0.18.3, not 0.19.2

Before you merge, I'm going to test this first.