### PR TITLE
Fix crashes encountered in replaying a story

### DIFF
--- a/src/node.c
+++ b/src/node.c
@@ -797,10 +797,13 @@ i7_node_find_child(I7Node *self, const gchar *command)
 {
 	I7Node *node = NULL;
 	GNode *gnode = self->gnode->children;
+	/* Special case: NULL is treated as "" */
+	if (!command) {
+		command = "";
+	}
 	while(gnode != NULL) {
 		gchar *cmp_command = i7_node_get_command(I7_NODE(gnode->data));
-		/* Special case: NULL is treated as "" */
-		if((strlen(cmp_command) == 0 && (command == NULL || strlen(command) == 0)) || (strcmp(cmp_command, command) == 0)) {
+		if((strlen(cmp_command) == 0 && strlen(command) == 0) || strcmp(cmp_command, command) == 0) {
 			g_free(cmp_command);
 			node = gnode->data;
 			break;

--- a/src/skein.c
+++ b/src/skein.c
@@ -1164,10 +1164,12 @@ reinstate_all_in_model(I7Skein *self)
 I7Node *
 i7_skein_new_command(I7Skein *self, const gchar *command)
 {
+	g_return_val_if_fail(command != NULL, NULL);
+
 	I7_SKEIN_USE_PRIVATE;
 
 	gboolean node_added = FALSE;
-	gchar *node_command = g_strescape(command ? command : "", "\"");
+	gchar *node_command = g_strescape(command, "\"");
 
 	I7Node *node = i7_node_find_child(priv->played, node_command);
 	if(node == NULL) {

--- a/src/skein.c
+++ b/src/skein.c
@@ -1167,7 +1167,7 @@ i7_skein_new_command(I7Skein *self, const gchar *command)
 	I7_SKEIN_USE_PRIVATE;
 
 	gboolean node_added = FALSE;
-	gchar *node_command = g_strescape(command, "\"");
+	gchar *node_command = g_strescape(command ? command : "", "\"");
 
 	I7Node *node = i7_node_find_child(priv->played, node_command);
 	if(node == NULL) {

--- a/src/story-game.c
+++ b/src/story-game.c
@@ -414,8 +414,8 @@ on_game_command(ChimaraIF *game, gchar *input, gchar *response, I7Story *story)
 		I7Node *root = i7_skein_get_root_node(priv->skein);
 		if(i7_skein_get_current_node(priv->skein) == root) {
 			i7_node_set_transcript_text(root, response);
-			return;
 		}
+		return;
 	} 
 	I7Node *node = i7_skein_new_command(priv->skein, input);
 	i7_node_set_transcript_text(node, response);


### PR DESCRIPTION
    -- in some (admittedly amateurish) attempts to replace
    a behavior, a blank or NULL command would sneak into
    the list
    -- I was seeing GTK-Critical messages from NULL passed to
    g_strescape, which was returned as-is and allowed NULL values to
    propagate
    -- This change accounts for such values outside of tests to avoid
    errors and clarify the logic for node addition in the skein

-----------------

I am an absolute noob with Inform7 here, so I'm unsure what exactly to attach if you want a reproducible case.  I wanted to get an account with mantis but never got the registration email, so this serves as the bug report ;).  

The test story below is cribbed from an example with some additions of my own.  The main new bits (above Rideable Vehicles) which exposed the issue for me were from the extra extensions and the bits about Mr Jones and the delay when overriding the actions for stealing his hat.  The crash I saw, thereafter, was pretty reproducible by doing "take top hat", especially when replaying.  After the rule completes, the Story tab would say, "I beg your pardon?" because a null string somehow made it into play.  Or it would just crash ;)

```
"Test 0" by Ed Swartz, based on example code

Include Rideable Vehicles by Graham Nelson.
Include Basic Help Menu by Emily Short.
Include Basic Screen Effects by Emily Short.
Include Real-Time Delays by Erik Temple.

Section - Room Setup

The Vehicle Testing Center is a room. "A large square of field surrounded by a wall of hay bales. A driveway leads out to the west. The ground slopes down to a pond along the northern edge."
A sign is a thing in the Center. "The sign advertises experimental rides in the following: [list of vehicular things][clear vehicles]." [what??]
To say clear vehicles:
	now every vehicular thing is unmentioned.
The red wagon is a vehicle in the Vehicle Testing Center. "There is a lovely [say red letters]red[say default letters] wagon here, complete with an outboard motor."
The swan is a rideable animal in the Vehicle Testing Center. "At the pond's edge waits a black swan of unusual size, wearing a bridle and a gold-trimmed Mexican hat." The description of the swan is "The swan looks back at you."

Mr Jones is here.  He wears a top hat.  "Mr. Jones stands uncomfortably near the sign.  His Lincoln-esque stovepive hat is ridiculous in this day and age."  Understand "stovepipe" as the top hat. 
 
Before taking the top hat:
	if Mr Jones is wearing the top hat:
		say "YOINK!";
		wait 1000 milliseconds before continuing;
		say "You steal the top hat from Mr. Jones and he frets helplessly.";
		now the top hat is carried by the player;
		the rule succeeds.

[this below is rote copying but seems to be required to reproduce]

Section - Vehicle Actions 

The swan can be fed or unfed.

Instead of mounting the unfed swan:
	say "The swan gives you a look of disappointment and reproach. Apparently it doesn't work for free."

Some chow is carried by the player. The description is "Delicious Purina swan chow pellets!"

Instead of giving the chow to the swan:
	now the swan is fed;
	say "The swan courteously accepts your offering."

Instead of going to the Dusty Road by swan:
	say "The swan honks indignantly at the very notion."

Instead of going to the Open Sky by swan:
	say "The swan can swim with you aboard, but not lift off."

After going somewhere by swan:
	say "The swan honks a lovely Mexican serenade as it paddles you about.";
	continue the action.

The Pond is north of the Vehicle Testing Center. "Funny, the pond is bigger from the middle than it seemed from the shore. In fact, you can't see any edge but the testing center to the south and a small island to the north."

Instead of going to the Pond when the player is not carried by the swan:
	say "You forgot your water skis."

Instead of dismounting when the location is the Pond:
	say "You'd fall in!"

North of the Pond is the Small Island.

The glass elevator is a vehicle in the Small Island. It is transparent. "A glass elevator stands in the center, a fantastically strong microfilament connecting it to... something in the sky."

The Open Sky is above the Small Island. "There's a great view from here, starting with that lovely glass floor. In fact, maybe you'd better not look that way."

Instead of going a direction (called the way) when the player is in the Elevator:
	if the way is up, continue the action;
	if the way is down, continue the action;
	say "The elevator ascends and descends only."

Instead of going to the Open Sky when the player is not in the Elevator:
	say "Do you plan to flap your arms, then?"

Instead of exiting in the Open Sky:
	say "It's a long way down."

The Dusty Road is west of the Vehicle Testing Center. "Off to the east is an enclosed area for the testing of dangerous and improbable vehicles."

A rideable vehicle called a tricycle is in the Dusty Road.  The tricycle is portable.

Test me with "test wagon / test tricycle / test swan / test elevator".

Test wagon with "get in wagon / w / e / e / w / out".

Test tricycle with "get in wagon / mount tricycle /  e / n / w / e / dismount".

Test swan with "n / get on swan / give chow to swan / mount swan / dismount / mount swan / n / dismount / swan, n / dismount".

Test elevator with "u / get in elevator / get out / get in elevator / up / get out / d".

```