### PR TITLE
Reformat appstream XML to pass validate-relax

### DIFF
--- a/com.inform7.IDE.appdata.xml
+++ b/com.inform7.IDE.appdata.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-​<component type="desktop-application">
+<component type="desktop-application">
   ​<id>com.inform7.IDE</id>
-  ​<metadata_license>CC0-1.0</metadata_license>
-  ​<project_license>LicenseRef-Compiler-InformLicense-EverthingElseGPL-3.0</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-Compiler-InformLicense-EverthingElseGPL-3.0</project_license>
   <content_rating type="oars-1.0" />
-  ​<name>Inform 7</name>
+  <name>Inform 7</name>
   <summary>Write interactive fiction</summary>
   <description>
     <p>
-      ​Inform is a design system for interactive fiction based on natural
+      Inform is a design system for interactive fiction based on natural
       language.
     </p>
     <p>
@@ -18,20 +18,15 @@
       as possible.
     </p>
   ​</description>
-  ​<launchable type="desktop-id">com.inform7.IDE.desktop</launchable>
-  ​<url type="homepage">http://inform7.com/</url>
-  ​<provides>
-    ​<binary>gnome-inform7</binary>
-  ​</provides>​
-  ​<releases>
-    ​<release version="6M62" date="2015-12-24">
-      ​<description>
-        ​<p>
-          This is for the most part a maintenance release of Inform,
-          incorporating fixes for nearly 300 issues reported with the previous
-          build, but there are also minor language improvements.
-        </p>
-      ​</description>
-    ​</release>
-  ​</releases>
-​</component>
+  <launchable type="desktop-id">com.inform7.IDE.desktop</launchable>
+  <url type="homepage">http://inform7.com/</url>
+  <provides><binary>gnome-inform7</binary></provides>
+  <releases>
+    ​<release version="6M62" date="2015-12-24"><description>
+      <p>
+        This is for the most part a maintenance release of Inform,
+        incorporating fixes for nearly 300 issues reported with the previous
+        build, but there are also minor language improvements.
+      </p>
+    </description></release>
+  </releases></component>


### PR DESCRIPTION
For the Flathub packaging effort, I had to reformat the appstream XML a bit, so I'm pushing the changes back upstream. The XML properly passes `appstream-util validate-relax` now.