### PR TITLE
Remove "provides" element from appstream XML

### DIFF
--- a/com.inform7.IDE.appdata.xml
+++ b/com.inform7.IDE.appdata.xml
@@ -20,7 +20,6 @@
   ​</description>
   <launchable type="desktop-id">com.inform7.IDE.desktop</launchable>
   <url type="homepage">http://inform7.com/</url>
-  <provides><binary>gnome-inform7</binary></provides>
   <releases>
     ​<release version="6M62" date="2015-12-24"><description>
       <p>


### PR DESCRIPTION
Flathub developers requested this change to the appstream XML, because this information is already indirectly provided by the `launchable` element, which points to the `.desktop` file.