### PR TITLE
Fix crash when skipping down long skein paths.

### DIFF
--- a/src/skein-view.c
+++ b/src/skein-view.c
@@ -344,6 +344,12 @@ i7_skein_view_show_node(I7SkeinView *self, I7Node *node, I7SkeinShowNodeReason w
 			I7Skein *skein = i7_skein_view_get_skein(self);
 			gdouble vspacing, x, y, width, height;
 
+			/* Give up if drawing is in progress */
+			if (!g_mutex_trylock(&skein->drawing_mutex))
+			{
+				return;
+			}
+
 			/* Work out the position of the node */
 			g_object_get(skein, "vertical-spacing", &vspacing, NULL);
 			x = i7_node_get_x(node);
@@ -358,6 +364,7 @@ i7_skein_view_show_node(I7SkeinView *self, I7Node *node, I7SkeinShowNodeReason w
 			height = gtk_adjustment_get_page_size(adj);
 
 			goo_canvas_scroll_to(GOO_CANVAS(self), x - width * 0.5, y - height * 0.5);
+			g_mutex_unlock(&skein->drawing_mutex);
 		}
 			break;
 		default:

--- a/src/skein.h
+++ b/src/skein.h
@@ -77,6 +77,7 @@ struct _I7SkeinClass
 struct _I7Skein
 {
 	GooCanvasGroupModel parent_instance;
+	GMutex drawing_mutex;
 };
 
 typedef enum _I7SkeinError {


### PR DESCRIPTION
When I hit "Play All" in the skein, I get one of
* Gdk:ERROR:gdkregion-generic.c:1110:miUnionNonO: assertion failed: (y1 < y2)
* malloc_consolidate(): invalid chunk size
* segfault
at random.

Apparently thread "glk" can call i7_skein_view_show_node
while thread "gnome-inform7" is in the middle of draw_intern,
so I think the cause was these two threads trying to manipulate the
same GooCanvas at the same time and tripping over each other.

One idea was to move draw_intern into the glk thread, but the GThread
is stored in ChimaraGlkPrivate so I guess we shouldn't mess with that.

So instead this patch makes draw_intern and i7_skein_view_show_node
fight over a GMutex; draw_intern will block since I'm scared to let
redraws fail or reschedule themselves, but i7_skein_view_show_node just
gives up if it can't lock the mutex---all it does is scroll the node
into view, and how much do we really care if that sometimes fails?