### PR TITLE
Fix crash when skipping down long skein paths, take 2.

### DIFF
--- a/src/skein.c
+++ b/src/skein.c
@@ -1118,7 +1118,7 @@ i7_skein_schedule_draw(I7Skein *self, GooCanvas *canvas)
 	DrawData *draw_data = g_slice_new0(DrawData);
 	draw_data->skein = self;
 	draw_data->canvas = canvas;
-	g_idle_add_full(G_PRIORITY_DEFAULT_IDLE, (GSourceFunc)idle_draw, draw_data, (GDestroyNotify)destroy_draw_data);
+	gdk_threads_add_idle_full(G_PRIORITY_DEFAULT_IDLE, (GSourceFunc)idle_draw, draw_data, (GDestroyNotify)destroy_draw_data);
 }
 
 /* Remove all the rows from the tree model, in preparation for a complicated


### PR DESCRIPTION
...by making idle_draw() hold the GDK lock.

This is a replacement for PR #10.

When I hit "Play All" in the skein, I get one of
* Gdk:ERROR:gdkregion-generic.c:1110:miUnionNonO: assertion failed: (y1 < y2)
* Gdk:ERROR:gdkregion-generic.c:1123:miUnionNonO: assertion failed: (pReg->numRects<=pReg->size)
* malloc_consolidate(): invalid chunk size
* segfault
at random.

Apparently thread "glk" can call i7_skein_view_show_node()
while thread "gnome-inform7" is in the middle of idle_draw(),
so the immediate cause looks like two threads trying to manipulate
the same GooCanvas at the same time and tripping over each other.

The relevant call to i7_skein_view_show_node() is made with the GDK
lock held; see emit_command_signal_on_active_inputs() in chimara-if.c.
But idle_draw() has no such protection, so we cope by calling it via
gdk_threads_add_idle_full() (i.e. g_idle_add_full() but hold the GDK
lock while the callback runs). At least on my machine, this appears to
prevent the collision in "Play All".