### PR TITLE
updating chimara submodule to github repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/ptomato/osxcart 
 [submodule "src/chimara"]
 	path = src/chimara
-	url = http://git.stderr.nl/projects/chimara/chimara.git
+	url = https://github.com/chimara/Chimara.git


### PR DESCRIPTION
Removed the existing submodule and folder, then re-added the submodule using the github-based chimara repo.