### PR TITLE
FIX: set story setting in the nested dict

### DIFF
--- a/src/story-settings.c
+++ b/src/story-settings.c
@@ -34,7 +34,7 @@ insert_setting(plist_t dict, const char *key1, const char *key2, plist_t setting
 		category = plist_new_dict();
 		plist_dict_set_item(dict, key1, category);
 	}
-	plist_dict_set_item(dict, key2, setting);
+	plist_dict_set_item(category, key2, setting);
 }
 
 /* Initialize a new settings dictionary with the defaults for our port */


### PR DESCRIPTION
This should fix a bug where settings were inserted at the top level instead of at their correct nesting.

I'm no C person, so please do check that this makes sense!